### PR TITLE
feat: support non-english characters

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/rfberaldo/sqlz/binds"
 )
@@ -17,7 +19,7 @@ type Parser struct {
 	bind         binds.Bind
 	position     int
 	readPosition int
-	ch           byte
+	ch           rune
 	idents       []string
 	identCount   int
 	bindCount    int
@@ -34,7 +36,7 @@ type namedOptions struct {
 }
 
 func (p *Parser) parseNamed(opts namedOptions) (string, []string) {
-	p.readChar()
+	p.read()
 	p.output.skip = opts.skipQuery
 	p.output.Grow(len(p.input)) // max will be len(input)
 
@@ -46,8 +48,8 @@ func (p *Parser) parseNamed(opts namedOptions) (string, []string) {
 			break
 		}
 
-		p.output.WriteByte(p.ch)
-		p.readChar()
+		p.output.WriteRune(p.ch)
+		p.read()
 	}
 
 	return p.output.String(), p.idents
@@ -56,24 +58,26 @@ func (p *Parser) parseNamed(opts namedOptions) (string, []string) {
 func (p *Parser) skipWhitespace() {
 	pos := p.readPosition
 
-	for isWhitespace(p.ch) {
-		p.readChar()
+	for unicode.IsSpace(p.ch) {
+		p.read()
 	}
 
 	if p.readPosition > pos {
-		p.output.WriteByte(' ')
+		p.output.WriteRune(' ')
 	}
 }
 
-func (p *Parser) readChar() {
+func (p *Parser) read() {
 	if p.readPosition >= len(p.input) {
 		p.ch = EOF
+		p.position = p.readPosition
+		p.readPosition += 1
 	} else {
-		p.ch = p.input[p.readPosition]
+		r, size := utf8.DecodeRuneInString(p.input[p.readPosition:])
+		p.ch = r
+		p.position = p.readPosition
+		p.readPosition += size
 	}
-
-	p.position = p.readPosition
-	p.readPosition += 1
 }
 
 func (p *Parser) tryReadIdent(skipIdents bool) {
@@ -82,13 +86,13 @@ func (p *Parser) tryReadIdent(skipIdents bool) {
 		return
 	}
 
-	// escaped placeholder, advance one char
-	if p.peekChar() == placeholder {
-		p.readChar()
+	// escaped placeholder, read next
+	if p.peek() == placeholder {
+		p.read()
 		return
 	}
 
-	if !isLetter(p.peekChar()) {
+	if !unicode.IsLetter(p.peek()) {
 		return
 	}
 
@@ -105,41 +109,42 @@ func (p *Parser) tryReadIdent(skipIdents bool) {
 
 		switch p.bind {
 		case binds.Question:
-			p.output.WriteByte('?')
+			p.output.WriteRune('?')
 		case binds.Colon:
-			p.output.WriteByte(':')
+			p.output.WriteRune(':')
 			p.output.WriteString(ident)
 		case binds.At:
 			p.output.WriteString("@p")
 			p.output.WriteString(strconv.Itoa(p.bindCount))
 		case binds.Dollar:
-			p.output.WriteByte('$')
+			p.output.WriteRune('$')
 			p.output.WriteString(strconv.Itoa(p.bindCount))
 		}
 
 		isLast := i == count-1
 		if count > 1 && !isLast {
-			p.output.WriteByte(',')
+			p.output.WriteRune(',')
 		}
 	}
 }
 
-// readIdent will readChar while strategy(ch)=true.
-func (p *Parser) readIdent(strategy func(ch byte) bool) string {
-	p.readChar()
+// readIdent will [read] while strategy(ch)=true.
+func (p *Parser) readIdent(strategy strategyFn) string {
+	p.read()
 	position := p.position
 	for strategy(p.ch) {
-		p.readChar()
+		p.read()
 	}
 	return p.input[position:p.position]
 }
 
-func (p *Parser) peekChar() byte {
-	return p.input[p.readPosition]
+func (p *Parser) peek() rune {
+	r, _ := utf8.DecodeRuneInString(p.input[p.readPosition:])
+	return r
 }
 
 func (p *Parser) parseIn() string {
-	p.readChar()
+	p.read()
 	p.output.Grow(len(p.input) + 2) // min will be len(input)+2
 
 	for {
@@ -150,8 +155,8 @@ func (p *Parser) parseIn() string {
 			break
 		}
 
-		p.output.WriteByte(p.ch)
-		p.readChar()
+		p.output.WriteRune(p.ch)
+		p.read()
 	}
 
 	return p.output.String()
@@ -160,13 +165,13 @@ func (p *Parser) parseIn() string {
 func (p *Parser) tryReadPlaceholder() {
 	placeholder, readStrategy, isNumbered := getBindInfo(p.bind)
 
-	if p.ch != placeholder {
+	if p.ch != rune(placeholder) {
 		return
 	}
 
-	// escaped placeholder, advance one char
-	if p.peekChar() == placeholder {
-		p.readChar()
+	// escaped placeholder, read next
+	if p.peek() == rune(placeholder) {
+		p.read()
 		return
 	}
 
@@ -174,7 +179,7 @@ func (p *Parser) tryReadPlaceholder() {
 	if readStrategy != nil {
 		ident = p.readIdent(readStrategy)
 	} else {
-		p.readChar()
+		p.read()
 	}
 	p.identCount++
 	count := p.inClauseCountByIndex[p.identCount-1]
@@ -182,7 +187,7 @@ func (p *Parser) tryReadPlaceholder() {
 
 	for i := range count {
 		p.bindCount++
-		p.output.WriteByte(placeholder)
+		p.output.WriteRune(placeholder)
 		if p.bind == binds.Colon {
 			p.output.WriteString(ident)
 		}
@@ -192,25 +197,27 @@ func (p *Parser) tryReadPlaceholder() {
 
 		isLast := i == count-1
 		if count > 1 && !isLast {
-			p.output.WriteByte(',')
+			p.output.WriteRune(',')
 		}
 	}
 }
 
-func getBindInfo(bind binds.Bind) (byte, func(ch byte) bool, bool) {
-	var placeholder byte
-	var readStrategy func(ch byte) bool
+type strategyFn = func(ch rune) bool
+
+func getBindInfo(bind binds.Bind) (rune, strategyFn, bool) {
+	var placeholder rune
+	var readStrategy strategyFn
 	var isNumbered bool
 
 	switch bind {
 	case binds.At:
 		placeholder = '@'
-		readStrategy = isNumber
+		readStrategy = unicode.IsNumber
 		isNumbered = true
 
 	case binds.Dollar:
 		placeholder = '$'
-		readStrategy = isNumber
+		readStrategy = unicode.IsNumber
 		isNumbered = true
 
 	case binds.Colon:
@@ -224,23 +231,8 @@ func getBindInfo(bind binds.Bind) (byte, func(ch byte) bool, bool) {
 	return placeholder, readStrategy, isNumbered
 }
 
-func isLetter(ch byte) bool {
-	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z'
-}
-
-func isNumber(ch byte) bool {
-	return '0' <= ch && ch <= '9'
-}
-
-func isIdentChar(ch byte) bool {
-	return ch == '_' || ch == '.' ||
-		'a' <= ch && ch <= 'z' ||
-		'A' <= ch && ch <= 'Z' ||
-		'0' <= ch && ch <= '9'
-}
-
-func isWhitespace(ch byte) bool {
-	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+func isIdentChar(ch rune) bool {
+	return ch == '_' || ch == '.' || unicode.IsLetter(ch) || unicode.IsNumber(ch)
 }
 
 func spreadSliceValues(args ...any) (map[int]int, []any, error) {
@@ -289,11 +281,11 @@ func (sb *stringBuilder) String() string {
 	return sb.sb.String()
 }
 
-func (sb *stringBuilder) WriteByte(c byte) error {
+func (sb *stringBuilder) WriteRune(r rune) (int, error) {
 	if sb.skip {
-		return nil
+		return 0, nil
 	}
-	return sb.sb.WriteByte(c)
+	return sb.sb.WriteRune(r)
 }
 
 func (sb *stringBuilder) WriteString(s string) (int, error) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -526,11 +526,6 @@ func TestConcurrency(t *testing.T) {
 	}
 }
 
-// goos: linux
-// goarch: amd64
-// pkg: github.com/rfberaldo/sqlz/named-parser
-// cpu: AMD Ryzen 5 5600X 6-Core Processor
-// BenchmarkParser-12    	    7802	    144034 ns/op	  302981 B/op	      32 allocs/op
 func BenchmarkParser(b *testing.B) {
 	var sb strings.Builder
 	sb.WriteString(`INSERT INTO user (id, username, email, password, age) VALUES (:id, :username, :email, :password, :age)`)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -136,16 +136,15 @@ func TestParse(t *testing.T) {
 			expectedQuestion: "",
 			expectedIdents:   nil,
 		},
-		// TODO: add an option to parse using runes instead of bytes
-		// {
-		// 	name:             "non english characters",
-		// 	input:            "INSERT INTO foo (a, b, c) VALUES (:あ, :b, :名前)",
-		// 	expectedAt:       "INSERT INTO foo (a, b, c) VALUES (@p1, @p2, @p3)",
-		// 	expectedColon:    "INSERT INTO foo (a, b, c) VALUES (:あ, :b, :名前)",
-		// 	expectedDollar:   "INSERT INTO foo (a, b, c) VALUES ($1, $2, $3)",
-		// 	expectedQuestion: "INSERT INTO foo (a, b, c) VALUES (?, ?, ?)",
-		// 	expectedIdents:   []string{"あ", "b", "名前"},
-		// },
+		{
+			name:             "non english characters",
+			input:            "INSERT INTO foo (a, b, c) VALUES (:あ, :b, :名前)",
+			expectedAt:       "INSERT INTO foo (a, b, c) VALUES (@p1, @p2, @p3)",
+			expectedColon:    "INSERT INTO foo (a, b, c) VALUES (:あ, :b, :名前)",
+			expectedDollar:   "INSERT INTO foo (a, b, c) VALUES ($1, $2, $3)",
+			expectedQuestion: "INSERT INTO foo (a, b, c) VALUES (?, ?, ?)",
+			expectedIdents:   []string{"あ", "b", "名前"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR enables non-english characters in named queries.

> About 85% slower running the parser only.
```
name       old time/op    new time/op    delta
Parser-12     220µs ± 2%     410µs ± 1%  +86.57%  (p=0.000 n=10+10)

name       old alloc/op   new alloc/op   delta
Parser-12     289kB ± 0%     289kB ± 0%   +0.01%  (p=0.000 n=9+10)

name       old allocs/op  new allocs/op  delta
Parser-12      16.0 ± 0%      16.0 ± 0%     ~     (all equal)
```

> About 6% slower running end-to-end.
```
name                    old time/op    new time/op    delta
PlaceholderExec-12        4.22µs ± 1%    4.37µs ± 4%  +3.72%  (p=0.003 n=9+10)
PlaceholderQueryRow-12    4.75µs ± 2%    5.16µs ± 4%  +8.60%  (p=0.000 n=10+10)
NamedQueryRow-12          5.54µs ± 9%    6.01µs ± 4%  +8.38%  (p=0.000 n=10+10)
BatchInsertStruct-12      1.32ms ± 4%    1.33ms ± 3%    ~     (p=0.247 n=10+10)
BatchInsertMap-12         1.22ms ± 4%    1.26ms ± 6%    ~     (p=0.105 n=10+10)
StructScan-12             1.48ms ± 5%    1.46ms ± 2%    ~     (p=0.143 n=10+10)
StringScan-12              425µs ± 4%     418µs ± 1%    ~     (p=0.353 n=10+10)
NamedInClause-12          72.8µs ± 6%    75.1µs ± 4%    ~     (p=0.053 n=10+9)
PlaceholderInClause-12    71.5µs ± 3%    73.8µs ± 4%  +3.25%  (p=0.004 n=10+10)
CustomStructTag-12        71.3µs ± 1%    74.8µs ± 4%  +4.94%  (p=0.000 n=10+9)

name                    old alloc/op   new alloc/op   delta
PlaceholderExec-12          424B ± 0%      424B ± 0%    ~     (all equal)
PlaceholderQueryRow-12      832B ± 0%      832B ± 0%    ~     (all equal)
NamedQueryRow-12            976B ± 0%      976B ± 0%    ~     (all equal)
BatchInsertStruct-12       670kB ± 0%     670kB ± 0%    ~     (p=0.156 n=9+10)
BatchInsertMap-12          605kB ± 0%     605kB ± 0%    ~     (p=0.631 n=10+10)
StructScan-12              226kB ± 0%     226kB ± 0%    ~     (p=0.345 n=9+10)
StringScan-12             57.6kB ± 0%    57.6kB ± 0%    ~     (p=0.289 n=10+10)
NamedInClause-12          13.5kB ± 0%    13.5kB ± 0%  +0.02%  (p=0.025 n=10+10)
PlaceholderInClause-12    13.4kB ± 0%    13.4kB ± 0%  +0.02%  (p=0.001 n=8+10)
CustomStructTag-12        13.4kB ± 0%    13.4kB ± 0%  +0.01%  (p=0.000 n=10+9)

name                    old allocs/op  new allocs/op  delta
PlaceholderExec-12          13.0 ± 0%      13.0 ± 0%    ~     (all equal)
PlaceholderQueryRow-12      26.0 ± 0%      26.0 ± 0%    ~     (all equal)
NamedQueryRow-12            31.0 ± 0%      31.0 ± 0%    ~     (all equal)
BatchInsertStruct-12       5.05k ± 0%     5.05k ± 0%    ~     (all equal)
BatchInsertMap-12          4.02k ± 0%     4.02k ± 0%    ~     (p=0.370 n=10+10)
StructScan-12              7.71k ± 0%     7.71k ± 0%    ~     (all equal)
StringScan-12              2.04k ± 0%     2.04k ± 0%    ~     (all equal)
NamedInClause-12             354 ± 0%       354 ± 0%    ~     (all equal)
PlaceholderInClause-12       350 ± 0%       350 ± 0%    ~     (all equal)
CustomStructTag-12           350 ± 0%       350 ± 0%    ~     (all equal)
```