### PR TITLE
feat: logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ go get github.com/rfberaldo/sqlz
 // there's 2 ways of connecting:
 
 // 1. using [sqlz.Connect]
-db, err := sqlz.Connect("sqlite3", ":memory:")
+db, err := sqlz.Connect("sqlite3", ":memory:", nil)
 
 // 2. using [sql.Open] and [sqlz.New]
 pool, err := sql.Open("sqlite3", ":memory:")
@@ -111,6 +111,7 @@ err = tx.Commit()
 
 To find the key of a struct property, sqlz first try to find the `db` tag,
 if it's not present, it then converts the property name to snake case.
+To set a custom tag use [Options](#options).
 
 ```go
 type User struct {
@@ -120,13 +121,21 @@ type User struct {
 }
 ```
 
-#### Custom struct tag
+### Options
 
-To set a custom struct tag, use `Options`:
+sqlz has a few options, use `sqlz.Options` as third parameter of `New` or `Connect`.
+At the moment it's possible to change the default struct tag, and set a logger using `slog`.
 
 ```go
+// 1. using [sqlz.New]
 pool, err := sql.Open("sqlite3", ":memory:")
 db := sqlz.New("sqlite3", pool, &sqlz.Options{StructTag: "json"})
+
+// 2. using [sqlz.Connect]
+db, err := sqlz.Connect("sqlite3", ":memory:", &sqlz.Options{
+  StructTag: "json",
+  Logger: slog.Default(),
+})
 ```
 
 ## Dependencies

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/sqlogger/README.md
+++ b/sqlogger/README.md
@@ -1,0 +1,24 @@
+# SQLogger
+
+SQLogger is a logger for `database/sql`, it wrapps the underlying connection making it
+very transparent, you're still using `sql.DB` object.
+It's like a fork of [sqldb-logger](https://github.com/simukti/sqldb-logger)
+with `slog` support and more opinionated.
+
+## Getting started
+
+> [!NOTE]
+> If you're using it with `sqlz`, just use `sqlz.Options`.
+
+### Connect to database
+
+```go
+// there's 2 ways of connecting:
+
+// 1. using [sqlogger.Open]
+db, err := sqlogger.Open("sqlite3", ":memory:", slog.Default(), nil)
+
+// 2. using [sqlogger.New]
+// instead of driver name, it expects the [driver.Driver]
+db := sqlogger.New(&sqlite3.SQLiteDriver{}, ":memory:", slog.Default(), nil)
+```

--- a/sqlogger/README.md
+++ b/sqlogger/README.md
@@ -1,19 +1,23 @@
 # SQLogger
 
-SQLogger is a logger for `database/sql`, it wrapps the underlying connection making it
-very transparent, you're still using `sql.DB` object.
-It's like a fork of [sqldb-logger](https://github.com/simukti/sqldb-logger)
-with `slog` support and more opinionated.
+SQLogger is a logger for `database/sql`, it wrapps the underlying connection making it very transparent, it returns a standard `sql.DB` object.
+It's like a fork of [sqldb-logger](https://github.com/simukti/sqldb-logger) with `slog` support and more opinionated.
 
 ## Getting started
 
 > [!NOTE]
 > If you're using it with `sqlz`, just use `sqlz.Options`.
 
-### Connect to database
+### Install
+
+```bash
+go get github.com/rfberaldo/sqlz/sqlogger
+```
+
+### Open a database
 
 ```go
-// there's 2 ways of connecting:
+// there's 2 ways of opening a database:
 
 // 1. using [sqlogger.Open]
 db, err := sqlogger.Open("sqlite3", ":memory:", slog.Default(), nil)
@@ -21,4 +25,14 @@ db, err := sqlogger.Open("sqlite3", ":memory:", slog.Default(), nil)
 // 2. using [sqlogger.New]
 // instead of driver name, it expects the [driver.Driver]
 db := sqlogger.New(&sqlite3.SQLiteDriver{}, ":memory:", slog.Default(), nil)
+```
+
+## Options
+
+Use `sqlogger.Options` as fourth parameter of `New` or `Open`:
+
+```go
+db, err := sqlogger.Open("sqlite3", ":memory:", slog.Default(), &sqlogger.Options{
+  // options...
+})
 ```

--- a/sqlogger/connection.go
+++ b/sqlogger/connection.go
@@ -1,0 +1,274 @@
+package sqlogger
+
+import (
+	"context"
+	"database/sql/driver"
+	"log/slog"
+	"time"
+)
+
+// connection implements
+// [driver.Conn]
+// [driver.ConnBeginTx]
+// [driver.ConnPrepareContext]
+// [driver.Pinger]
+// [driver.Execer]
+// [driver.ExecerContext]
+// [driver.Queryer]
+// [driver.QueryerContext]
+// [driver.SessionResetter]
+// [driver.NamedValueChecker]
+type connection struct {
+	driver.Conn
+	id     string
+	logger *sqlogger
+}
+
+// Begin implements [driver.Conn]
+func (c *connection) Begin() (driver.Tx, error) {
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelDebug
+	id := c.logger.IdGenerator()
+	attrs := append(c.logData(), slog.String(txKey, id))
+
+	tx, err := c.Conn.Begin()
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "Begin", start, err, attrs...)
+
+	return &transaction{tx, id, c.id, c.logger}, err
+}
+
+// Prepare implements [driver.Conn]
+func (c *connection) Prepare(query string) (driver.Stmt, error) {
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelInfo
+	id := c.logger.IdGenerator()
+	attrs := append(c.logData(), slog.String(stmtKey, id), slog.String("query", query))
+
+	stmt, err := c.Conn.Prepare(query)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "Prepare", start, err, attrs...)
+
+	return &statement{stmt, id, c.id, query, c.logger}, err
+}
+
+// Prepare implements [driver.Conn]
+func (c *connection) Close() error {
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelDebug
+
+	err := c.Conn.Close()
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "Close", start, err, c.logData()...)
+
+	return err
+}
+
+// BeginTx implements [driver.ConnBeginTx]
+func (c *connection) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	drvTx, ok := c.Conn.(driver.ConnBeginTx)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	start := time.Now()
+	lvl := slog.LevelDebug
+	id := c.logger.IdGenerator()
+	attrs := append(c.logData(), slog.String(txKey, id))
+
+	tx, err := drvTx.BeginTx(ctx, opts)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "BeginTx", start, err, attrs...)
+
+	return &transaction{tx, id, c.id, c.logger}, err
+}
+
+// PrepareContext implements [driver.ConnPrepareContext]
+func (c *connection) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	driverPrep, ok := c.Conn.(driver.ConnPrepareContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	start := time.Now()
+	lvl := slog.LevelInfo
+	id := c.logger.IdGenerator()
+	attrs := append(c.logData(), slog.String(stmtKey, id), slog.String("query", query))
+
+	stmt, err := driverPrep.PrepareContext(ctx, query)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "PrepareContext", start, err, attrs...)
+
+	return &statement{stmt, id, c.id, query, c.logger}, err
+}
+
+// Ping implements [driver.Pinger]
+func (c *connection) Ping(ctx context.Context) error {
+	driverPinger, ok := c.Conn.(driver.Pinger)
+	if !ok {
+		return driver.ErrSkip
+	}
+
+	start := time.Now()
+	lvl := slog.LevelDebug
+
+	err := driverPinger.Ping(ctx)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "Ping", start, err, c.logData()...)
+
+	return err
+}
+
+// Exec implements [driver.Execer]
+func (c *connection) Exec(query string, args []driver.Value) (driver.Result, error) {
+	driverExecer, ok := c.Conn.(driver.Execer)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelInfo
+	attrs := append(c.logData(), slog.String("query", query), slog.Any("args", args))
+
+	res, err := driverExecer.Exec(query, args)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "Exec", start, err, attrs...)
+
+	return res, err
+}
+
+// ExecContext implements [driver.ExecerContext]
+func (c *connection) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	driverExecerContext, ok := c.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	start := time.Now()
+	lvl := slog.LevelInfo
+	attrs := append(c.logData(), slog.String("query", query), slog.Any("args", valuesFromNamedArgs(args)))
+
+	res, err := driverExecerContext.ExecContext(ctx, query, args)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "ExecContext", start, err, attrs...)
+
+	return res, err
+}
+
+// Query implements [driver.Queryer]
+func (c *connection) Query(query string, args []driver.Value) (driver.Rows, error) {
+	driverQueryer, ok := c.Conn.(driver.Queryer)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelInfo
+	attrs := append(c.logData(), slog.String("query", query), slog.Any("args", args))
+
+	rows, err := driverQueryer.Query(query, args)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "Query", start, err, attrs...)
+
+	return rows, err
+}
+
+// QueryContext implements [driver.QueryerContext]
+func (c *connection) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	driverQueryerContext, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	start := time.Now()
+	lvl := slog.LevelInfo
+	attrs := append(c.logData(), slog.String("query", query), slog.Any("args", valuesFromNamedArgs(args)))
+
+	rows, err := driverQueryerContext.QueryContext(ctx, query, args)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "QueryContext", start, err, attrs...)
+
+	return rows, err
+}
+
+// ResetSession implements [driver.SessionResetter]
+func (c *connection) ResetSession(ctx context.Context) error {
+	resetter, ok := c.Conn.(driver.SessionResetter)
+	if !ok {
+		return driver.ErrSkip
+	}
+
+	start := time.Now()
+	lvl := slog.LevelDebug
+
+	err := resetter.ResetSession(ctx)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "ResetSession", start, err, c.logData()...)
+
+	return err
+}
+
+// CheckNamedValue implements [driver.NamedValueChecker]
+func (c *connection) CheckNamedValue(nm *driver.NamedValue) error {
+	checker, ok := c.Conn.(driver.NamedValueChecker)
+	if !ok {
+		return driver.ErrSkip
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelDebug
+
+	err := checker.CheckNamedValue(nm)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "CheckNamedValue", start, err, c.logData()...)
+
+	return err
+}
+
+func (c *connection) logData() []slog.Attr {
+	return []slog.Attr{
+		slog.String(connKey, c.id),
+	}
+}

--- a/sqlogger/connection.go
+++ b/sqlogger/connection.go
@@ -29,7 +29,7 @@ func (c *connection) Begin() (driver.Tx, error) {
 	ctx := context.Background()
 	start := time.Now()
 	lvl := slog.LevelDebug
-	id := c.logger.IdGenerator()
+	id := c.logger.idGenerator()
 	attrs := append(c.logData(), slog.String(txKey, id))
 
 	tx, err := c.Conn.Begin()
@@ -46,9 +46,9 @@ func (c *connection) Begin() (driver.Tx, error) {
 func (c *connection) Prepare(query string) (driver.Stmt, error) {
 	ctx := context.Background()
 	start := time.Now()
-	lvl := slog.LevelInfo
-	id := c.logger.IdGenerator()
-	attrs := append(c.logData(), slog.String(stmtKey, id), slog.String("query", query))
+	lvl := slog.LevelDebug
+	id := c.logger.idGenerator()
+	attrs := append(c.logData(), slog.String(stmtKey, id), slog.String(queryKey, query))
 
 	stmt, err := c.Conn.Prepare(query)
 	if err != nil {
@@ -60,7 +60,7 @@ func (c *connection) Prepare(query string) (driver.Stmt, error) {
 	return &statement{stmt, id, c.id, query, c.logger}, err
 }
 
-// Prepare implements [driver.Conn]
+// Close implements [driver.Conn]
 func (c *connection) Close() error {
 	ctx := context.Background()
 	start := time.Now()
@@ -85,7 +85,7 @@ func (c *connection) BeginTx(ctx context.Context, opts driver.TxOptions) (driver
 
 	start := time.Now()
 	lvl := slog.LevelDebug
-	id := c.logger.IdGenerator()
+	id := c.logger.idGenerator()
 	attrs := append(c.logData(), slog.String(txKey, id))
 
 	tx, err := drvTx.BeginTx(ctx, opts)
@@ -106,9 +106,9 @@ func (c *connection) PrepareContext(ctx context.Context, query string) (driver.S
 	}
 
 	start := time.Now()
-	lvl := slog.LevelInfo
-	id := c.logger.IdGenerator()
-	attrs := append(c.logData(), slog.String(stmtKey, id), slog.String("query", query))
+	lvl := slog.LevelDebug
+	id := c.logger.idGenerator()
+	attrs := append(c.logData(), slog.String(stmtKey, id), slog.String(queryKey, query))
 
 	stmt, err := driverPrep.PrepareContext(ctx, query)
 	if err != nil {
@@ -150,7 +150,7 @@ func (c *connection) Exec(query string, args []driver.Value) (driver.Result, err
 	ctx := context.Background()
 	start := time.Now()
 	lvl := slog.LevelInfo
-	attrs := append(c.logData(), slog.String("query", query), slog.Any("args", args))
+	attrs := append(c.logData(), slog.String(queryKey, query), slog.Any(argsKey, args))
 
 	res, err := driverExecer.Exec(query, args)
 	if err != nil {
@@ -171,7 +171,7 @@ func (c *connection) ExecContext(ctx context.Context, query string, args []drive
 
 	start := time.Now()
 	lvl := slog.LevelInfo
-	attrs := append(c.logData(), slog.String("query", query), slog.Any("args", valuesFromNamedArgs(args)))
+	attrs := append(c.logData(), slog.String(queryKey, query), slog.Any(argsKey, valuesFromNamedArgs(args)))
 
 	res, err := driverExecerContext.ExecContext(ctx, query, args)
 	if err != nil {
@@ -193,7 +193,7 @@ func (c *connection) Query(query string, args []driver.Value) (driver.Rows, erro
 	ctx := context.Background()
 	start := time.Now()
 	lvl := slog.LevelInfo
-	attrs := append(c.logData(), slog.String("query", query), slog.Any("args", args))
+	attrs := append(c.logData(), slog.String(queryKey, query), slog.Any(argsKey, args))
 
 	rows, err := driverQueryer.Query(query, args)
 	if err != nil {
@@ -214,7 +214,7 @@ func (c *connection) QueryContext(ctx context.Context, query string, args []driv
 
 	start := time.Now()
 	lvl := slog.LevelInfo
-	attrs := append(c.logData(), slog.String("query", query), slog.Any("args", valuesFromNamedArgs(args)))
+	attrs := append(c.logData(), slog.String(queryKey, query), slog.Any(argsKey, valuesFromNamedArgs(args)))
 
 	rows, err := driverQueryerContext.QueryContext(ctx, query, args)
 	if err != nil {

--- a/sqlogger/connection_test.go
+++ b/sqlogger/connection_test.go
@@ -1,0 +1,473 @@
+package sqlogger
+
+import (
+	"database/sql/driver"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestConnection_Begin(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		connMock := &connMock{}
+		txMock := &transactionMock{}
+		connMock.On("Begin").Return(txMock, nil)
+
+		conn := &connection{connMock, randomId(), tLogger}
+		tx, err := conn.Begin()
+		assert.NoError(t, err)
+		assert.Implements(t, (*driver.Tx)(nil), tx)
+		assert.Equal(t, "Begin", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		connMock := &connMock{}
+		var txMock *transactionMock
+		connMock.On("Begin").Return(txMock, driver.ErrBadConn)
+
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.Begin()
+		assert.Error(t, err)
+
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+}
+
+func TestConnection_Prepare(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		connMock := &connMock{}
+		stmtMock := &statementMock{}
+		connMock.On("Prepare", mock.Anything).Return(stmtMock, nil)
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		stmt, err := conn.Prepare(q)
+		assert.NoError(t, err)
+		assert.Implements(t, (*driver.Stmt)(nil), stmt)
+		assert.Equal(t, "Prepare", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, conn.id, output.data.ConnId)
+		assert.NotEmpty(t, output.data.StmtId)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		connMock := &connMock{}
+		var stmtMock *statementMock
+		connMock.On("Prepare", mock.Anything).Return(stmtMock, driver.ErrBadConn)
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.Prepare(q)
+		assert.Error(t, err)
+		assert.Equal(t, "Prepare", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+}
+
+func TestConnection_Close(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		connMock := &connMock{}
+		connMock.On("Close").Return(nil)
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.Close()
+		assert.NoError(t, err)
+		assert.Equal(t, "Close", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		connMock := &connMock{}
+		connMock.On("Close").Return(driver.ErrBadConn)
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.Close()
+		assert.Error(t, err)
+		assert.Equal(t, "Close", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+}
+
+func TestConnection_BeginTx(t *testing.T) {
+	t.Run("With driver.ConnBeginTx Success", func(t *testing.T) {
+		connMock := &connMock{}
+		txMock := &transactionMock{}
+		connMock.On("BeginTx", mock.Anything, mock.Anything).Return(txMock, nil)
+
+		conn := &connection{connMock, randomId(), tLogger}
+		tx, err := conn.BeginTx(ctx, driver.TxOptions{
+			Isolation: 1,
+			ReadOnly:  true,
+		})
+		assert.NoError(t, err)
+		assert.Implements(t, (*driver.Tx)(nil), tx)
+
+		assert.Equal(t, "BeginTx", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.Equal(t, conn.id, output.data.ConnId)
+		assert.NotEmpty(t, output.data.TxId)
+	})
+
+	t.Run("With driver.ConnBeginTx Error", func(t *testing.T) {
+		connMock := &connMock{}
+		var txMock *transactionMock
+		connMock.On("BeginTx", mock.Anything, mock.Anything).Return(txMock, driver.ErrBadConn)
+
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.BeginTx(ctx, driver.TxOptions{
+			Isolation: 1,
+			ReadOnly:  true,
+		})
+		assert.Error(t, err)
+
+		assert.Equal(t, "BeginTx", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, conn.id, output.data.ConnId)
+		assert.NotEmpty(t, output.data.TxId)
+	})
+
+	t.Run("Non driver.ConnBeginTx", func(t *testing.T) {
+		connMock := &basicConnMock{}
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.BeginTx(ctx, driver.TxOptions{
+			Isolation: 1,
+			ReadOnly:  true,
+		})
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}
+
+func TestConnection_PrepareContext(t *testing.T) {
+	t.Run("With driver.ConnBeginTx Success", func(t *testing.T) {
+		connMock := &connMock{}
+		stmtMock := &statementMock{}
+		connMock.On("PrepareContext", mock.Anything).Return(stmtMock, nil)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		stmt, err := conn.PrepareContext(ctx, q)
+		assert.NoError(t, err)
+		assert.Implements(t, (*driver.Stmt)(nil), stmt)
+		assert.Equal(t, "PrepareContext", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, conn.id, output.data.ConnId)
+		assert.NotEmpty(t, output.data.StmtId)
+	})
+
+	t.Run("With driver.ConnPrepareContext Error", func(t *testing.T) {
+		connMock := &connMock{}
+		var stmtMock *statementMock
+		connMock.On("PrepareContext", mock.Anything).Return(stmtMock, driver.ErrBadConn)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.PrepareContext(ctx, q)
+		assert.Error(t, err)
+
+		assert.Equal(t, "PrepareContext", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, conn.id, output.data.ConnId)
+		assert.NotEmpty(t, output.data.StmtId)
+	})
+
+	t.Run("Non driver.ConnPrepareContext", func(t *testing.T) {
+		connMock := &basicConnMock{}
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.PrepareContext(ctx, q)
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}
+
+func TestConnection_Ping(t *testing.T) {
+	t.Run("driver.Pinger Success", func(t *testing.T) {
+		connMock := &connMock{}
+		connMock.On("Ping", mock.Anything).Return(nil)
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.Ping(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "Ping", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("driver.Pinger With Error", func(t *testing.T) {
+		connMock := &connMock{}
+		connMock.On("Ping", mock.Anything).Return(driver.ErrBadConn)
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.Ping(ctx)
+		assert.Error(t, err)
+
+		assert.Equal(t, "Ping", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Non driver.Pinger", func(t *testing.T) {
+		connMock := &basicConnMock{}
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.Ping(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}
+
+func TestConnection_Exec(t *testing.T) {
+	t.Run("driver.Execer Success", func(t *testing.T) {
+		connMock := &connMock{}
+		resultMock := driver.ResultNoRows
+		connMock.On("Exec", mock.Anything, mock.Anything).Return(resultMock, nil)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.Exec(q, []driver.Value{"testid"})
+		assert.NoError(t, err)
+
+		assert.Equal(t, "Exec", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("driver.Execer Return Error", func(t *testing.T) {
+		connMock := &connMock{}
+		resultMock := driver.ResultNoRows
+		connMock.On("Exec", mock.Anything, mock.Anything).Return(resultMock, driver.ErrBadConn)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.Exec(q, []driver.Value{1})
+		assert.Error(t, err)
+		assert.Equal(t, interface{}(driver.ErrBadConn), err)
+
+		assert.Equal(t, "Exec", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Non driver.Execer Will Return Error", func(t *testing.T) {
+		connMock := &basicConnMock{}
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		res, err := conn.Exec(q, []driver.Value{1})
+		assert.Nil(t, res)
+		assert.Error(t, err)
+		assert.Equal(t, interface{}(driver.ErrSkip), err)
+	})
+}
+
+func TestConnection_ExecContext(t *testing.T) {
+	t.Run("driver.ExecerContext Success", func(t *testing.T) {
+		connMock := &connMock{}
+		resultMock := driver.ResultNoRows
+		connMock.On("ExecContext", mock.Anything, mock.Anything, mock.Anything).Return(resultMock, nil)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.ExecContext(ctx, q, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.NoError(t, err)
+
+		assert.Equal(t, "ExecContext", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("driver.ExecerContext Return Error", func(t *testing.T) {
+		connMock := &connMock{}
+		resultMock := driver.ResultNoRows
+		connMock.On("ExecContext", mock.Anything, mock.Anything, mock.Anything).Return(resultMock, driver.ErrBadConn)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.ExecContext(ctx, q, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.Error(t, err)
+
+		assert.Equal(t, "ExecContext", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Non driver.ExecerContext Return Error args", func(t *testing.T) {
+		connMock := &basicConnMock{}
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.ExecContext(ctx, q, []driver.NamedValue{
+			{Name: "errrrr", Ordinal: 0, Value: 1},
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestConnection_Query(t *testing.T) {
+	t.Run("driver.Queryer Success", func(t *testing.T) {
+		connMock := &connMock{}
+		resultMock := &rowsMock{}
+		connMock.On("Query", mock.Anything, mock.Anything).Return(resultMock, nil)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.Query(q, []driver.Value{"testid"})
+		assert.NoError(t, err)
+
+		assert.Equal(t, "Query", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("driver.Queryer Return Error", func(t *testing.T) {
+		connMock := &connMock{}
+		resultMock := &rowsMock{}
+		connMock.On("Query", mock.Anything, mock.Anything).Return(resultMock, driver.ErrBadConn)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.Query(q, []driver.Value{"testid"})
+		assert.Error(t, err)
+		assert.Equal(t, interface{}(driver.ErrBadConn), err)
+
+		assert.Equal(t, "Query", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Non driver.Queryer Will Return Error", func(t *testing.T) {
+		connMock := &basicConnMock{}
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		res, err := conn.Query(q, []driver.Value{1})
+		assert.Nil(t, res)
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}
+
+func TestConnection_QueryContext(t *testing.T) {
+	t.Run("driver.QueryerContext Success", func(t *testing.T) {
+		connMock := &connMock{}
+		resultMock := &rowsMock{}
+		connMock.On("QueryContext", mock.Anything, mock.Anything, mock.Anything).Return(resultMock, nil)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.QueryContext(ctx, q, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.NoError(t, err)
+		assert.Equal(t, "QueryContext", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("driver.QueryerContext Return Error", func(t *testing.T) {
+		connMock := &connMock{}
+		resultMock := &rowsMock{}
+		connMock.On("QueryContext", mock.Anything, mock.Anything, mock.Anything).Return(resultMock, driver.ErrBadConn)
+
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.QueryContext(ctx, q, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.Error(t, err)
+		assert.Equal(t, "QueryContext", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Non driver.QueryerContext Return Error args", func(t *testing.T) {
+		connMock := &basicConnMock{}
+		q := "SELECT * FROM tt WHERE id = ?"
+		conn := &connection{connMock, randomId(), tLogger}
+		_, err := conn.QueryContext(ctx, q, []driver.NamedValue{
+			{Name: "errrrr", Ordinal: 0, Value: 1},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}
+
+func TestConnection_ResetSession(t *testing.T) {
+	t.Run("driver.SessionResetter Return Error", func(t *testing.T) {
+		connMock := &connMock{}
+		connMock.On("ResetSession", mock.Anything).Return(driver.ErrBadConn)
+
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.ResetSession(ctx)
+		assert.Error(t, err)
+
+		assert.Equal(t, "ResetSession", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Non driver.SessionResetter", func(t *testing.T) {
+		connMock := &basicConnMock{}
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.ResetSession(ctx)
+		assert.Error(t, err)
+		assert.Error(t, driver.ErrSkip, err)
+	})
+}
+
+func TestConnection_CheckNamedValue(t *testing.T) {
+	t.Run("driver.NamedValueChecker Return Error", func(t *testing.T) {
+		connMock := &connMock{}
+		connMock.On("CheckNamedValue", mock.Anything).Return(driver.ErrBadConn)
+
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.CheckNamedValue(&driver.NamedValue{
+			Name:    "",
+			Ordinal: 0,
+			Value:   "testid",
+		})
+		assert.Error(t, err)
+
+		assert.Equal(t, "CheckNamedValue", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.NotEmpty(t, output.data.ConnId)
+		assert.Equal(t, conn.id, output.data.ConnId)
+	})
+
+	t.Run("Non driver.NamedValueChecker", func(t *testing.T) {
+		connMock := &basicConnMock{}
+		conn := &connection{connMock, randomId(), tLogger}
+		err := conn.CheckNamedValue(&driver.NamedValue{
+			Name:    "",
+			Ordinal: 0,
+			Value:   "testid",
+		})
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}

--- a/sqlogger/connection_test.go
+++ b/sqlogger/connection_test.go
@@ -49,7 +49,7 @@ func TestConnection_Prepare(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Implements(t, (*driver.Stmt)(nil), stmt)
 		assert.Equal(t, "Prepare", output.data.Msg)
-		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
 		assert.Equal(t, q, output.data.Query)
 		assert.Equal(t, conn.id, output.data.ConnId)
 		assert.NotEmpty(t, output.data.StmtId)
@@ -157,7 +157,7 @@ func TestConnection_PrepareContext(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Implements(t, (*driver.Stmt)(nil), stmt)
 		assert.Equal(t, "PrepareContext", output.data.Msg)
-		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
 		assert.Equal(t, q, output.data.Query)
 		assert.Equal(t, conn.id, output.data.ConnId)
 		assert.NotEmpty(t, output.data.StmtId)
@@ -241,7 +241,7 @@ func TestConnection_Exec(t *testing.T) {
 		assert.Equal(t, "Exec", output.data.Msg)
 		assert.Equal(t, slog.LevelInfo, output.data.Level)
 		assert.Equal(t, q, output.data.Query)
-		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
 		assert.Equal(t, conn.id, output.data.ConnId)
 	})
 
@@ -254,7 +254,7 @@ func TestConnection_Exec(t *testing.T) {
 		conn := &connection{connMock, randomId(), tLogger}
 		_, err := conn.Exec(q, []driver.Value{1})
 		assert.Error(t, err)
-		assert.Equal(t, interface{}(driver.ErrBadConn), err)
+		assert.Equal(t, any(driver.ErrBadConn), err)
 
 		assert.Equal(t, "Exec", output.data.Msg)
 		assert.Equal(t, slog.LevelError, output.data.Level)
@@ -271,7 +271,7 @@ func TestConnection_Exec(t *testing.T) {
 		res, err := conn.Exec(q, []driver.Value{1})
 		assert.Nil(t, res)
 		assert.Error(t, err)
-		assert.Equal(t, interface{}(driver.ErrSkip), err)
+		assert.Equal(t, any(driver.ErrSkip), err)
 	})
 }
 
@@ -289,7 +289,7 @@ func TestConnection_ExecContext(t *testing.T) {
 		assert.Equal(t, "ExecContext", output.data.Msg)
 		assert.Equal(t, slog.LevelInfo, output.data.Level)
 		assert.Equal(t, q, output.data.Query)
-		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
 		assert.Equal(t, conn.id, output.data.ConnId)
 	})
 
@@ -307,7 +307,7 @@ func TestConnection_ExecContext(t *testing.T) {
 		assert.Equal(t, slog.LevelError, output.data.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
 		assert.Equal(t, q, output.data.Query)
-		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
 		assert.Equal(t, conn.id, output.data.ConnId)
 	})
 
@@ -336,7 +336,7 @@ func TestConnection_Query(t *testing.T) {
 		assert.Equal(t, "Query", output.data.Msg)
 		assert.Equal(t, slog.LevelInfo, output.data.Level)
 		assert.Equal(t, q, output.data.Query)
-		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
 		assert.Equal(t, conn.id, output.data.ConnId)
 	})
 
@@ -349,13 +349,13 @@ func TestConnection_Query(t *testing.T) {
 		conn := &connection{connMock, randomId(), tLogger}
 		_, err := conn.Query(q, []driver.Value{"testid"})
 		assert.Error(t, err)
-		assert.Equal(t, interface{}(driver.ErrBadConn), err)
+		assert.Equal(t, any(driver.ErrBadConn), err)
 
 		assert.Equal(t, "Query", output.data.Msg)
 		assert.Equal(t, slog.LevelError, output.data.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
 		assert.Equal(t, q, output.data.Query)
-		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
 		assert.Equal(t, conn.id, output.data.ConnId)
 	})
 
@@ -384,7 +384,7 @@ func TestConnection_QueryContext(t *testing.T) {
 		assert.Equal(t, "QueryContext", output.data.Msg)
 		assert.Equal(t, slog.LevelInfo, output.data.Level)
 		assert.Equal(t, q, output.data.Query)
-		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
 		assert.Equal(t, conn.id, output.data.ConnId)
 	})
 
@@ -401,7 +401,7 @@ func TestConnection_QueryContext(t *testing.T) {
 		assert.Equal(t, slog.LevelError, output.data.Level)
 		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
 		assert.Equal(t, q, output.data.Query)
-		assert.Equal(t, []interface{}{"testid"}, output.data.Args)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
 		assert.Equal(t, conn.id, output.data.ConnId)
 	})
 

--- a/sqlogger/connector.go
+++ b/sqlogger/connector.go
@@ -1,0 +1,32 @@
+package sqlogger
+
+import (
+	"context"
+	"database/sql/driver"
+	"log/slog"
+	"time"
+)
+
+// connector implements [driver.Connector]
+type connector struct {
+	dsn    string
+	driver driver.Driver
+	logger *sqlogger
+}
+
+func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
+	start := time.Now()
+	lvl := slog.LevelDebug
+	id := c.logger.IdGenerator()
+
+	conn, err := c.driver.Open(c.dsn)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	c.logger.log(ctx, lvl, "Connect", start, err, slog.String(connKey, id))
+
+	return &connection{conn, id, c.logger}, err
+}
+
+func (c *connector) Driver() driver.Driver { return c.driver }

--- a/sqlogger/connector.go
+++ b/sqlogger/connector.go
@@ -17,7 +17,7 @@ type connector struct {
 func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	start := time.Now()
 	lvl := slog.LevelDebug
-	id := c.logger.IdGenerator()
+	id := c.logger.idGenerator()
 
 	conn, err := c.driver.Open(c.dsn)
 	if err != nil {

--- a/sqlogger/connector_test.go
+++ b/sqlogger/connector_test.go
@@ -1,0 +1,42 @@
+package sqlogger
+
+import (
+	"database/sql/driver"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestConnector_Connect(t *testing.T) {
+	t.Run("Connect Success", func(t *testing.T) {
+		mockDriver := &driverMock{}
+		mockDriver.On("Open", mock.Anything).Return(&connMock{}, nil)
+
+		conn := &connector{"sqlite3", mockDriver, tLogger}
+		_, err := conn.Connect(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "Connect", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.NotEmpty(t, output.data.ConnId)
+	})
+
+	t.Run("Connect Error", func(t *testing.T) {
+		mockDriver := &driverMock{}
+		mockDriver.On("Open", mock.Anything).Return(&connMock{}, driver.ErrBadConn)
+
+		conn := &connector{"test", mockDriver, tLogger}
+		_, err := conn.Connect(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, "Connect", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.NotEmpty(t, output.data.ConnId)
+	})
+}
+
+func TestConnector_Driver(t *testing.T) {
+	mockDriver := &driverMock{}
+	conn := &connector{"test", mockDriver, tLogger}
+	assert.Equal(t, mockDriver, conn.Driver())
+}

--- a/sqlogger/example_test.go
+++ b/sqlogger/example_test.go
@@ -1,0 +1,50 @@
+package sqlogger_test
+
+import (
+	"log"
+	"log/slog"
+
+	"github.com/mattn/go-sqlite3"
+	"github.com/rfberaldo/sqlz/sqlogger"
+)
+
+func ExampleOpen() {
+	// [sqlogger.Open] is similar to [sql.Open], with two additional parameters:
+	// [slog.Logger] and [sqlogger.Options]
+	db, err := sqlogger.Open("sqlite3", ":memory:", slog.Default(), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = db.Exec("CREATE TABLE user (id INT PRIMARY KEY, name TEXT")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleOpen_options() {
+	opts := &sqlogger.Options{
+		// options...
+	}
+
+	// use sqlogger.Options as fourth parameter
+	db, err := sqlogger.Open("sqlite3", ":memory:", slog.Default(), opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = db.Exec("CREATE TABLE user (id INT PRIMARY KEY, name TEXT")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleNew() {
+	// [sqlogger.New] receive the [driver.Driver] instead of the driver name
+	db := sqlogger.New(&sqlite3.SQLiteDriver{}, ":memory:", slog.Default(), nil)
+
+	_, err := db.Exec("CREATE TABLE user (id INT PRIMARY KEY, name TEXT")
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/sqlogger/mocks_test.go
+++ b/sqlogger/mocks_test.go
@@ -1,0 +1,210 @@
+package sqlogger
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"log"
+	"log/slog"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
+
+var (
+	output   = &writerMock{}
+	tSlogger = slog.New(slog.NewJSONHandler(output, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	tLogger  = &sqlogger{tSlogger, randomId}
+	ctx      = context.Background()
+)
+
+type logData struct {
+	Time     time.Time     `json:"time"`
+	Level    slog.Level    `json:"level"`
+	Msg      string        `json:"msg"`
+	ConnId   string        `json:"conn_id"`
+	StmtId   string        `json:"stmt_id"`
+	TxId     string        `json:"tx_id"`
+	Error    string        `json:"error"`
+	Query    string        `json:"query"`
+	Args     []any         `json:"args"`
+	Duration time.Duration `json:"duration"`
+}
+
+// writerMock implements [io.Writer]
+type writerMock struct {
+	data logData
+}
+
+func (t *writerMock) Write(p []byte) (n int, err error) {
+	t.data = logData{}
+	err = json.Unmarshal(p, &t.data)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return n, err
+}
+
+// driverMock implements [driver.Driver]
+type driverMock struct {
+	mock.Mock
+}
+
+func (m *driverMock) Open(name string) (driver.Conn, error) {
+	arg := m.Called(name)
+	return arg.Get(0).(driver.Conn), arg.Error(1)
+}
+
+// transactionMock implements [driver.Tx]
+type transactionMock struct {
+	mock.Mock
+}
+
+func (m *transactionMock) Commit() error {
+	return m.Called().Error(0)
+}
+func (m *transactionMock) Rollback() error {
+	return m.Called().Error(0)
+}
+
+// statementMock implements
+// [driver.Stmt]
+// [driver.StmtExecContext]
+// [driver.StmtQueryContext]
+// [driver.NamedValueChecker]
+// [driver.ColumnConverter]
+type statementMock struct {
+	mock.Mock
+}
+
+func (m *statementMock) Close() error {
+	return m.Called().Error(0)
+}
+func (m *statementMock) NumInput() int {
+	return m.Called().Int(0)
+}
+func (m *statementMock) Exec(args []driver.Value) (driver.Result, error) {
+	arg := m.Called(args)
+	return arg.Get(0).(driver.Result), arg.Error(1)
+}
+func (m *statementMock) Query(args []driver.Value) (driver.Rows, error) {
+	arg := m.Called(args)
+	return arg.Get(0).(driver.Rows), arg.Error(1)
+}
+func (m *statementMock) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	arg := m.Called(ctx, args)
+	return arg.Get(0).(driver.Result), arg.Error(1)
+}
+func (m *statementMock) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	arg := m.Called(ctx, args)
+	return arg.Get(0).(driver.Rows), arg.Error(1)
+}
+func (m *statementMock) CheckNamedValue(nm *driver.NamedValue) error {
+	return m.Called().Error(0)
+}
+func (m *statementMock) ColumnConverter(idx int) driver.ValueConverter {
+	return m.Called(idx).Get(0).(driver.ValueConverter)
+}
+
+// basicStatementMock implements [driver.Stmt]
+type basicStatementMock struct {
+	mock.Mock
+}
+
+func (m *basicStatementMock) Close() error {
+	return m.Called().Error(0)
+}
+func (m *basicStatementMock) NumInput() int {
+	return m.Called().Int(0)
+}
+func (m *basicStatementMock) Exec(args []driver.Value) (driver.Result, error) {
+	arg := m.Called(args)
+	return arg.Get(0).(driver.Result), arg.Error(1)
+}
+func (m *basicStatementMock) Query(args []driver.Value) (driver.Rows, error) {
+	arg := m.Called(args)
+	return arg.Get(0).(driver.Rows), arg.Error(1)
+}
+
+// resultMock implements [driver.Result]
+type resultMock struct{}
+
+func (r *resultMock) LastInsertId() (int64, error) { return 0, nil }
+func (r *resultMock) RowsAffected() (int64, error) { return 0, nil }
+
+// rowsMock implements [driver.Rows]
+type rowsMock struct{}
+
+func (r *rowsMock) Columns() []string              { return []string{} }
+func (r *rowsMock) Close() error                   { return nil }
+func (r *rowsMock) Next(dest []driver.Value) error { return nil }
+
+// connMock implements
+// [driver.Conn]
+// [driver.ConnBeginTx]
+// [driver.ConnPrepareContext]
+// [driver.Pinger]
+// [driver.Execer]
+// [driver.ExecerContext]
+// [driver.Queryer]
+// [driver.QueryerContext]
+// [driver.SessionResetter]
+// [driver.NamedValueChecker]
+type connMock struct {
+	mock.Mock
+}
+
+func (m *connMock) Prepare(query string) (driver.Stmt, error) {
+	args := m.Called(query)
+	return args.Get(0).(driver.Stmt), args.Error(1)
+}
+func (m *connMock) Close() error { return m.Called().Error(0) }
+func (m *connMock) Begin() (driver.Tx, error) {
+	return m.Called().Get(0).(driver.Tx), m.Called().Error(1)
+}
+func (m *connMock) Exec(query string, args []driver.Value) (driver.Result, error) {
+	arg := m.Called(query, args)
+	return arg.Get(0).(driver.Result), arg.Error(1)
+}
+func (m *connMock) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	arg := m.Called(ctx, query, args)
+	return arg.Get(0).(driver.Result), arg.Error(1)
+}
+func (m *connMock) Query(query string, args []driver.Value) (driver.Rows, error) {
+	arg := m.Called(query, args)
+	return arg.Get(0).(driver.Rows), arg.Error(1)
+}
+func (m *connMock) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	arg := m.Called(ctx, query, args)
+	return arg.Get(0).(driver.Rows), arg.Error(1)
+}
+func (m *connMock) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	args := m.Called(ctx, opts)
+	return args.Get(0).(driver.Tx), args.Error(1)
+}
+func (m *connMock) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	args := m.Called(query)
+	return args.Get(0).(driver.Stmt), args.Error(1)
+}
+func (m *connMock) Ping(ctx context.Context) error { return m.Called().Error(0) }
+func (m *connMock) ResetSession(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}
+func (m *connMock) CheckNamedValue(nm *driver.NamedValue) error {
+	return m.Called(nm).Error(0)
+}
+
+// basicConnMock implements [driver.Conn]
+type basicConnMock struct {
+	mock.Mock
+}
+
+func (m *basicConnMock) Prepare(query string) (driver.Stmt, error) {
+	args := m.Called(query)
+	return args.Get(0).(driver.Stmt), args.Error(1)
+}
+func (m *basicConnMock) Close() error { return m.Called().Error(0) }
+func (m *basicConnMock) Begin() (driver.Tx, error) {
+	return m.Called().Get(0).(driver.Tx), m.Called().Error(1)
+}

--- a/sqlogger/mocks_test.go
+++ b/sqlogger/mocks_test.go
@@ -14,7 +14,7 @@ import (
 var (
 	output   = &writerMock{}
 	tSlogger = slog.New(slog.NewJSONHandler(output, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	tLogger  = &sqlogger{tSlogger, randomId}
+	tLogger  = &sqlogger{tSlogger, randomId, false}
 	ctx      = context.Background()
 )
 

--- a/sqlogger/sqlogger.go
+++ b/sqlogger/sqlogger.go
@@ -1,0 +1,136 @@
+package sqlogger
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"log/slog"
+	"math/rand"
+	"time"
+)
+
+const (
+	txKey   = "tx_id"
+	connKey = "conn_id"
+	stmtKey = "stmt_id"
+)
+
+// Logger is an instance of [slog.Logger]
+type Logger interface {
+	LogAttrs(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr)
+}
+
+// Options holds logging options to be used in [Open] or [New].
+// A zero Options consists entirely of default values.
+type Options struct {
+	// IdGenerator is a function that returns a string to be used as id.
+	// By default it's a 8-length random string.
+	IdGenerator func() string
+}
+
+// Open opens a database specified by its database driver name and a
+// driver-specific data source name.
+//
+// No database drivers are included in the Go standard library.
+// See https://golang.org/s/sqldrivers for a list of third-party drivers.
+//
+// Open may just validate its arguments without creating a connection
+// to the database. To verify that the data source name is valid, call
+// [DB.Ping].
+//
+// The returned [DB] is safe for concurrent use by multiple goroutines
+// and maintains its own pool of idle connections. Thus, the Open
+// function should be called just once.
+//
+// The logger argument is an instance of [slog.Logger].
+//
+// If opts is nil, the default options are used.
+func Open(driverName, dataSourceName string, logger Logger, opts *Options) (*sql.DB, error) {
+	db, err := sql.Open(driverName, dataSourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(db.Driver(), dataSourceName, logger, opts), nil
+}
+
+// New opens a database specified by its database driver and a
+// driver-specific data source name.
+//
+// No database drivers are included in the Go standard library.
+// See https://golang.org/s/sqldrivers for a list of third-party drivers.
+//
+// New may just validate its arguments without creating a connection
+// to the database. To verify that the data source name is valid, call
+// [DB.Ping].
+//
+// The returned [DB] is safe for concurrent use by multiple goroutines
+// and maintains its own pool of idle connections. Thus, the New
+// function should be called just once.
+//
+// The logger argument is an instance of [slog.Logger].
+//
+// If opts is nil, the default options are used.
+func New(driver driver.Driver, dataSourceName string, logger Logger, opts *Options) *sql.DB {
+	conn := &connector{
+		dsn:    dataSourceName,
+		driver: driver,
+		logger: &sqlogger{logger, randomId},
+	}
+
+	if opts == nil {
+		return sql.OpenDB(conn)
+	}
+
+	if opts.IdGenerator != nil {
+		conn.logger.IdGenerator = opts.IdGenerator
+	}
+
+	return sql.OpenDB(conn)
+}
+
+type sqlogger struct {
+	logger      Logger
+	IdGenerator func() string
+}
+
+func (l *sqlogger) log(
+	ctx context.Context,
+	level slog.Level,
+	msg string,
+	start time.Time,
+	err error,
+	attrs ...slog.Attr,
+) {
+	l.logger.LogAttrs(ctx, level, msg, buildAttrs(start, err, attrs...)...)
+}
+
+func buildAttrs(start time.Time, err error, attrs ...slog.Attr) []slog.Attr {
+	_attrs := make([]slog.Attr, 0, len(attrs)+2)
+	if err != nil {
+		attrs = append(attrs, slog.Any("error", err))
+	}
+	_attrs = append(_attrs, attrs...)
+	_attrs = append(_attrs, slog.Duration("duration", time.Since(start)))
+	return _attrs
+}
+
+func valuesFromNamedArgs(args []driver.NamedValue) []driver.Value {
+	values := make([]driver.Value, len(args))
+
+	for k, v := range args {
+		values[k] = v.Value
+	}
+
+	return values
+}
+
+// randomId generates a string with 8 random characters.
+func randomId() string {
+	const charset = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, 8)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/sqlogger/sqlogger_test.go
+++ b/sqlogger/sqlogger_test.go
@@ -66,3 +66,18 @@ func TestOpen(t *testing.T) {
 		assert.Equal(t, id, output.data.ConnId)
 	})
 }
+
+func TestCleanQuery(t *testing.T) {
+	input := `
+		SELECT * FROM
+			user
+		WHERE
+			name = ?
+		AND
+			id IN (?,?)
+		ORDER BY
+			name
+	`
+	expected := "SELECT * FROM user WHERE name = ? AND id IN (?,?) ORDER BY name"
+	assert.Equal(t, expected, cleanQuery(input))
+}

--- a/sqlogger/sqlogger_test.go
+++ b/sqlogger/sqlogger_test.go
@@ -1,0 +1,68 @@
+package sqlogger
+
+import (
+	"database/sql"
+	"log/slog"
+	"testing"
+
+	"github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("Without Options", func(t *testing.T) {
+		db := New(&sqlite3.SQLiteDriver{}, ":memory:", tSlogger, nil)
+		_, ok := any(db).(*sql.DB)
+		assert.True(t, ok)
+
+		err := db.Ping()
+		assert.NoError(t, err)
+		assert.Equal(t, "Ping", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+	})
+
+	t.Run("With Options", func(t *testing.T) {
+		id := randomId()
+		idGenerator := func() string { return id }
+
+		db := New(&sqlite3.SQLiteDriver{}, ":memory:", tSlogger, &Options{IdGenerator: idGenerator})
+		_, ok := any(db).(*sql.DB)
+		assert.True(t, ok)
+
+		err := db.Ping()
+		assert.NoError(t, err)
+		assert.Equal(t, "Ping", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.Equal(t, id, output.data.ConnId)
+	})
+}
+
+func TestOpen(t *testing.T) {
+	t.Run("Without Options", func(t *testing.T) {
+		db, err := Open("sqlite3", ":memory:", tSlogger, nil)
+		assert.NoError(t, err)
+		_, ok := any(db).(*sql.DB)
+		assert.True(t, ok)
+
+		err = db.Ping()
+		assert.NoError(t, err)
+		assert.Equal(t, "Ping", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+	})
+
+	t.Run("With Options", func(t *testing.T) {
+		id := randomId()
+		idGenerator := func() string { return id }
+
+		db, err := Open("sqlite3", ":memory:", tSlogger, &Options{IdGenerator: idGenerator})
+		assert.NoError(t, err)
+		_, ok := any(db).(*sql.DB)
+		assert.True(t, ok)
+
+		err = db.Ping()
+		assert.NoError(t, err)
+		assert.Equal(t, "Ping", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.Equal(t, id, output.data.ConnId)
+	})
+}

--- a/sqlogger/statement.go
+++ b/sqlogger/statement.go
@@ -47,7 +47,7 @@ func (s *statement) Exec(args []driver.Value) (driver.Result, error) {
 	ctx := context.Background()
 	start := time.Now()
 	lvl := slog.LevelInfo
-	attrs := append(s.logAttrs(), slog.Any("args", args))
+	attrs := append(s.logAttrs(), slog.Any(argsKey, args))
 
 	res, err := s.Stmt.Exec(args)
 	if err != nil {
@@ -64,7 +64,7 @@ func (s *statement) Query(args []driver.Value) (driver.Rows, error) {
 	ctx := context.Background()
 	start := time.Now()
 	lvl := slog.LevelInfo
-	attrs := append(s.logAttrs(), slog.Any("args", args))
+	attrs := append(s.logAttrs(), slog.Any(argsKey, args))
 
 	rows, err := s.Stmt.Query(args)
 	if err != nil {
@@ -85,7 +85,7 @@ func (s *statement) ExecContext(ctx context.Context, args []driver.NamedValue) (
 
 	start := time.Now()
 	lvl := slog.LevelInfo
-	attrs := append(s.logAttrs(), slog.Any("args", valuesFromNamedArgs(args)))
+	attrs := append(s.logAttrs(), slog.Any(argsKey, valuesFromNamedArgs(args)))
 
 	res, err := stmtExecer.ExecContext(ctx, args)
 	if err != nil {
@@ -106,7 +106,7 @@ func (s *statement) QueryContext(ctx context.Context, args []driver.NamedValue) 
 
 	start := time.Now()
 	lvl := slog.LevelInfo
-	attrs := append(s.logAttrs(), slog.Any("args", valuesFromNamedArgs(args)))
+	attrs := append(s.logAttrs(), slog.Any(argsKey, valuesFromNamedArgs(args)))
 
 	rows, err := stmtQueryer.QueryContext(ctx, args)
 	if err != nil {
@@ -152,6 +152,6 @@ func (s *statement) logAttrs() []slog.Attr {
 	return []slog.Attr{
 		slog.String(connKey, s.connId),
 		slog.String(stmtKey, s.id),
-		slog.String("query", s.query),
+		slog.String(queryKey, s.query),
 	}
 }

--- a/sqlogger/statement.go
+++ b/sqlogger/statement.go
@@ -1,0 +1,157 @@
+package sqlogger
+
+import (
+	"context"
+	"database/sql/driver"
+	"log/slog"
+	"time"
+)
+
+// statement implements
+// [driver.Stmt]
+// [driver.StmtExecContext]
+// [driver.StmtQueryContext]
+// [driver.NamedValueChecker]
+// [driver.ColumnConverter]
+type statement struct {
+	driver.Stmt
+	id     string
+	connId string
+	query  string
+	logger *sqlogger
+}
+
+// Close implements [driver.Stmt]
+func (s *statement) Close() error {
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelDebug
+
+	err := s.Stmt.Close()
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	s.logger.log(ctx, lvl, "StmtClose", start, err, s.logAttrs()...)
+
+	return err
+}
+
+// NumInput implements [driver.Stmt]
+func (s *statement) NumInput() int {
+	return s.Stmt.NumInput()
+}
+
+// Exec implements [driver.Stmt]
+func (s *statement) Exec(args []driver.Value) (driver.Result, error) {
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelInfo
+	attrs := append(s.logAttrs(), slog.Any("args", args))
+
+	res, err := s.Stmt.Exec(args)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	s.logger.log(ctx, lvl, "StmtExec", start, err, attrs...)
+
+	return res, err
+}
+
+// Query implements [driver.Stmt]
+func (s *statement) Query(args []driver.Value) (driver.Rows, error) {
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelInfo
+	attrs := append(s.logAttrs(), slog.Any("args", args))
+
+	rows, err := s.Stmt.Query(args)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	s.logger.log(ctx, lvl, "StmtQuery", start, err, attrs...)
+
+	return rows, err
+}
+
+// ExecContext implements [driver.StmtExecContext]
+func (s *statement) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	stmtExecer, ok := s.Stmt.(driver.StmtExecContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	start := time.Now()
+	lvl := slog.LevelInfo
+	attrs := append(s.logAttrs(), slog.Any("args", valuesFromNamedArgs(args)))
+
+	res, err := stmtExecer.ExecContext(ctx, args)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	s.logger.log(ctx, lvl, "StmtExecContext", start, err, attrs...)
+
+	return res, err
+}
+
+// QueryContext implements [driver.StmtQueryContext]
+func (s *statement) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	stmtQueryer, ok := s.Stmt.(driver.StmtQueryContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+
+	start := time.Now()
+	lvl := slog.LevelInfo
+	attrs := append(s.logAttrs(), slog.Any("args", valuesFromNamedArgs(args)))
+
+	rows, err := stmtQueryer.QueryContext(ctx, args)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	s.logger.log(ctx, lvl, "StmtQueryContext", start, err, attrs...)
+
+	return rows, err
+}
+
+// CheckNamedValue implements [driver.NamedValueChecker]
+func (s *statement) CheckNamedValue(nm *driver.NamedValue) error {
+	checker, ok := s.Stmt.(driver.NamedValueChecker)
+	if !ok {
+		return driver.ErrSkip
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelDebug
+
+	err := checker.CheckNamedValue(nm)
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	s.logger.log(ctx, lvl, "StmtCheckNamedValue", start, err, s.logAttrs()...)
+
+	return err
+}
+
+// ColumnConverter implements [driver.ColumnConverter]
+func (s *statement) ColumnConverter(idx int) driver.ValueConverter {
+	if converter, ok := s.Stmt.(driver.ColumnConverter); ok {
+		return converter.ColumnConverter(idx)
+	}
+
+	return driver.DefaultParameterConverter
+}
+
+func (s *statement) logAttrs() []slog.Attr {
+	return []slog.Attr{
+		slog.String(connKey, s.connId),
+		slog.String(stmtKey, s.id),
+		slog.String("query", s.query),
+	}
+}

--- a/sqlogger/statement_test.go
+++ b/sqlogger/statement_test.go
@@ -213,7 +213,7 @@ func TestStatement_ConnIdFlow(t *testing.T) {
 	q := "SELECT * FROM tt WHERE id = ?"
 	stmt, err := conn.Prepare(q)
 	assert.NoError(t, err)
-	assert.Equal(t, slog.LevelInfo, output.data.Level)
+	assert.Equal(t, slog.LevelDebug, output.data.Level)
 	assert.Equal(t, conn.id, output.data.ConnId)
 
 	_, err = stmt.Query([]driver.Value{1})

--- a/sqlogger/statement_test.go
+++ b/sqlogger/statement_test.go
@@ -1,0 +1,270 @@
+package sqlogger
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestStatement_Close(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("Close").Return(nil)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		err := stmt.Close()
+
+		fmt.Printf("%+v", output.data)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtClose", output.data.Msg)
+		assert.Equal(t, "", output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, stmt.connId, output.data.ConnId)
+		assert.Equal(t, stmt.id, output.data.StmtId)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("Close").Return(driver.ErrBadConn)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		err := stmt.Close()
+		assert.Error(t, err)
+		assert.Equal(t, "StmtClose", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, stmt.connId, output.data.ConnId)
+		assert.Equal(t, stmt.id, output.data.StmtId)
+	})
+}
+
+func TestStatement_NumInput(t *testing.T) {
+	q := "SELECT * FROM tt WHERE id = ?"
+	stmtMock := &statementMock{}
+	stmtMock.On("NumInput").Return(1)
+
+	stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+	input := stmt.NumInput()
+	assert.Equal(t, 1, input)
+}
+
+func TestStatement_Exec(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("Exec", mock.Anything).Return(&resultMock{}, nil)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		_, err := stmt.Exec([]driver.Value{"testid"})
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtExec", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("Exec", mock.Anything).Return(driver.ResultNoRows, driver.ErrBadConn)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		_, err := stmt.Exec([]driver.Value{"testid"})
+		assert.Error(t, err)
+		assert.Equal(t, "StmtExec", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
+	})
+}
+
+func TestStatement_Query(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("Query", mock.Anything).Return(&rowsMock{}, nil)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		_, err := stmt.Query([]driver.Value{"testid"})
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtQuery", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("Query", mock.Anything).Return(&rowsMock{}, driver.ErrBadConn)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		_, err := stmt.Query([]driver.Value{"testid"})
+		assert.Error(t, err)
+		assert.Equal(t, "StmtQuery", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
+	})
+}
+
+func TestStatement_ExecContext(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("ExecContext", mock.Anything, mock.Anything).Return(&resultMock{}, nil)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		_, err := stmt.ExecContext(ctx, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtExecContext", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("ExecContext", mock.Anything, mock.Anything).Return(&resultMock{}, driver.ErrBadConn)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		_, err := stmt.ExecContext(ctx, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrBadConn, err)
+		assert.Equal(t, "StmtExecContext", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
+	})
+
+	t.Run("Not implement driver.StmtExecContext", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &basicStatementMock{}
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+
+		_, err := stmt.ExecContext(ctx, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}
+
+func TestStatement_QueryContext(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("QueryContext", mock.Anything, mock.Anything).Return(&rowsMock{}, nil)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		_, err := stmt.QueryContext(ctx, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.NoError(t, err)
+		assert.Equal(t, "StmtQueryContext", output.data.Msg)
+		assert.Equal(t, slog.LevelInfo, output.data.Level)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &statementMock{}
+		stmtMock.On("QueryContext", mock.Anything, mock.Anything).Return(&rowsMock{}, driver.ErrBadConn)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+		_, err := stmt.QueryContext(ctx, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrBadConn, err)
+		assert.Equal(t, "StmtQueryContext", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, driver.ErrBadConn.Error(), output.data.Error)
+		assert.Equal(t, q, output.data.Query)
+		assert.Equal(t, []any{"testid"}, output.data.Args)
+	})
+
+	t.Run("Not implement driver.StmtQueryContext", func(t *testing.T) {
+		q := "SELECT * FROM tt WHERE id = ?"
+		stmtMock := &basicStatementMock{}
+		stmt := &statement{stmtMock, randomId(), randomId(), q, tLogger}
+
+		_, err := stmt.QueryContext(ctx, []driver.NamedValue{{Name: "", Ordinal: 0, Value: "testid"}})
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}
+
+func TestStatement_ConnIdFlow(t *testing.T) {
+	connMock := &connMock{}
+
+	stmtMock := &statementMock{}
+	stmtMock.On("Query", mock.Anything).Return(&rowsMock{}, nil)
+	connMock.On("Prepare", mock.Anything).Return(stmtMock, nil)
+	conn := &connection{connMock, randomId(), tLogger}
+
+	q := "SELECT * FROM tt WHERE id = ?"
+	stmt, err := conn.Prepare(q)
+	assert.NoError(t, err)
+	assert.Equal(t, slog.LevelInfo, output.data.Level)
+	assert.Equal(t, conn.id, output.data.ConnId)
+
+	_, err = stmt.Query([]driver.Value{1})
+	assert.NoError(t, err)
+	assert.Equal(t, slog.LevelInfo, output.data.Level)
+	assert.Equal(t, conn.id, output.data.ConnId)
+	assert.NotEmpty(t, output.data.StmtId)
+}
+
+func TestStatement_CheckNamedValue(t *testing.T) {
+	t.Run("Error", func(t *testing.T) {
+		stmtMock := &statementMock{}
+		stmtMock.On("CheckNamedValue", mock.Anything).Return(driver.ErrBadConn)
+
+		stmt := &statement{stmtMock, randomId(), randomId(), "", tLogger}
+		err := stmt.CheckNamedValue(&driver.NamedValue{Name: "", Ordinal: 0, Value: "testid"})
+		assert.Error(t, err)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, "StmtCheckNamedValue", output.data.Msg)
+		assert.NotEmpty(t, output.data.StmtId)
+		assert.NotEmpty(t, output.data.ConnId)
+	})
+
+	t.Run("Not implement driver.NamedValueChecker", func(t *testing.T) {
+		stmtMock := &basicStatementMock{}
+
+		stmt := &statement{stmtMock, randomId(), randomId(), "", tLogger}
+		err := stmt.CheckNamedValue(&driver.NamedValue{Name: "", Ordinal: 0, Value: "testid"})
+		assert.Error(t, err)
+		assert.Equal(t, driver.ErrSkip, err)
+	})
+}
+
+func TestStatement_ColumnConverter(t *testing.T) {
+	t.Run("Return as is", func(t *testing.T) {
+		stmtMock := &statementMock{}
+		stmtMock.On("ColumnConverter", mock.Anything).Return(driver.NotNull{Converter: driver.DefaultParameterConverter})
+
+		stmt := &statement{stmtMock, randomId(), randomId(), "", tLogger}
+		cnv := stmt.ColumnConverter(1)
+		val, err := cnv.ConvertValue(1)
+		assert.NoError(t, err)
+		intVal, ok := val.(int64)
+		assert.True(t, ok)
+		assert.Equal(t, int64(1), intVal)
+	})
+
+	t.Run("Not implement driver.ColumnConverter", func(t *testing.T) {
+		stmtMock := &basicStatementMock{}
+		stmt := &statement{stmtMock, randomId(), randomId(), "", tLogger}
+		cnv := stmt.ColumnConverter(1)
+		assert.Equal(t, driver.DefaultParameterConverter, cnv)
+	})
+}

--- a/sqlogger/transaction.go
+++ b/sqlogger/transaction.go
@@ -1,0 +1,53 @@
+package sqlogger
+
+import (
+	"context"
+	"database/sql/driver"
+	"log/slog"
+	"time"
+)
+
+// transaction implements [driver.Tx]
+type transaction struct {
+	driver.Tx
+	id     string
+	connId string
+	logger *sqlogger
+}
+
+func (tx *transaction) Commit() error {
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelDebug
+
+	err := tx.Tx.Commit()
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	tx.logger.log(ctx, lvl, "Commit", start, err, tx.logAttrs()...)
+
+	return err
+}
+
+func (tx *transaction) Rollback() error {
+	ctx := context.Background()
+	start := time.Now()
+	lvl := slog.LevelDebug
+
+	err := tx.Tx.Rollback()
+	if err != nil {
+		lvl = slog.LevelError
+	}
+
+	tx.logger.log(ctx, lvl, "Rollback", start, err, tx.logAttrs()...)
+
+	return err
+}
+
+func (tx *transaction) logAttrs() []slog.Attr {
+	return []slog.Attr{
+		slog.String(txKey, tx.id),
+		slog.String(connKey, tx.connId),
+	}
+}

--- a/sqlogger/transaction_test.go
+++ b/sqlogger/transaction_test.go
@@ -1,0 +1,65 @@
+package sqlogger
+
+import (
+	"database/sql/driver"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransaction_Commit(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		txMock := &transactionMock{}
+		txMock.On("Commit").Return(nil)
+
+		tx := &transaction{txMock, randomId(), randomId(), tLogger}
+		err := tx.Commit()
+		assert.NoError(t, err)
+		assert.Equal(t, "Commit", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.Equal(t, tx.id, output.data.TxId)
+		assert.Equal(t, tx.connId, output.data.ConnId)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		txMock := &transactionMock{}
+		txMock.On("Commit").Return(driver.ErrBadConn)
+
+		tx := &transaction{txMock, randomId(), randomId(), tLogger}
+		err := tx.Commit()
+		assert.Error(t, err)
+		assert.Equal(t, "Commit", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, tx.id, output.data.TxId)
+		assert.Equal(t, tx.connId, output.data.ConnId)
+	})
+}
+
+func TestTransaction_Rollback(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		txMock := &transactionMock{}
+		txMock.On("Rollback").Return(nil)
+
+		tx := &transaction{txMock, randomId(), randomId(), tLogger}
+		err := tx.Rollback()
+		assert.NoError(t, err)
+		assert.Equal(t, "Rollback", output.data.Msg)
+		assert.Equal(t, slog.LevelDebug, output.data.Level)
+		assert.Equal(t, tx.id, output.data.TxId)
+		assert.Equal(t, tx.connId, output.data.ConnId)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		txMock := &transactionMock{}
+		txMock.On("Rollback").Return(driver.ErrBadConn)
+
+		tx := &transaction{txMock, randomId(), randomId(), tLogger}
+		err := tx.Rollback()
+		assert.Error(t, err)
+		assert.Equal(t, "Rollback", output.data.Msg)
+		assert.Equal(t, slog.LevelError, output.data.Level)
+		assert.Equal(t, tx.id, output.data.TxId)
+		assert.Equal(t, tx.connId, output.data.ConnId)
+	})
+}


### PR DESCRIPTION
Add `sqlogger` package, which is almost a fork of https://github.com/simukti/sqldb-logger with slog support and more opinionated.
Breaking: add logger option to sqlz. Connect and MustConnect functions signature changed.

Example:

```
2025/03/27 17:52:27 INFO ExecContext query="CREATE TABLE TestTransaction_ozO ( id INT PRIMARY KEY, name VARCHAR(255), age INT )" conn_id=Ty7tgM duration=3.913661ms
2025/03/27 17:52:27 INFO ExecContext query="INSERT INTO TestTransaction_ozO (id, name, age) VALUES ($1,$2,$3),($4,$5,$6),($7,$8,$9)" args="[1 Alice 18 2 Rob 38 3 John 4]" conn_id=Ty7tgM duration=614.307µs
2025/03/27 17:52:27 INFO QueryContext query="SELECT count(1) FROM TestTransaction_ozO" conn_id=Ty7tgM duration=311.123µs
2025/03/27 17:52:27 INFO ExecContext query="DELETE FROM TestTransaction_ozO" conn_id=Ty7tgM duration=486.935µs
2025/03/27 17:52:27 INFO ExecContext query="INSERT INTO TestTransaction_ozO (id, name, age) VALUES ($1,$2,$3),($4,$5,$6),($7,$8,$9)" args="[1 Alice 18 2 Rob 38 3 John 4]" conn_id=Ty7tgM duration=128.631µs
2025/03/27 17:52:27 INFO QueryContext query="SELECT count(1) FROM TestTransaction_ozO" conn_id=Ty7tgM duration=116.081µs
2025/03/27 17:52:27 INFO ExecContext query="INSERT INTO TestTransaction_ozO (id, name, age) VALUES ($1,$2,$3),($4,$5,$6),($7,$8,$9)" args="[1 Alice 18 2 Rob 38 3 John 4]" conn_id=Ty7tgM duration=160.512µs
2025/03/27 17:52:27 ERROR Rollback error="timeout: context already done: context canceled" conn_id=Ty7tgM tx_id=FoPyiM duration=53.201µs
2025/03/27 17:52:27 ERROR ResetSession error="driver: bad connection" conn_id=Ty7tgM duration=490ns
2025/03/27 17:52:27 INFO QueryContext query="SELECT count(1) FROM TestTransaction_ozO" conn_id=MIcA61 duration=645.607µs
2025/03/27 17:52:27 INFO ExecContext query="DROP TABLE TestTransaction_ozO" conn_id=MIcA61 duration=1.360044ms
```